### PR TITLE
Behandlung von Grenzfällen

### DIFF
--- a/pixoo_display.py
+++ b/pixoo_display.py
@@ -80,10 +80,10 @@ def pixoo_text():
     if total_price < 0.3:
         pix.draw_image('images/ampel_gruen.png')
     # Ist der total_price größer als 0,3 und kleiner als 0,4 dann zeige gelbe Ampel
-    elif total_price > 0.3 and total_price < 0.4:
+    elif total_price >= 0.3 and total_price < 0.4:
         pix.draw_image('images/ampel_gelb.png')
     # Ist der total_price größer als 0,4 dann zeige rote Ampel
-    elif total_price > 0.4:
+    elif total_price >= 0.4:
         pix.draw_image('images/ampel_rot.png')
     
     # Schreibe die Texte auf dem Display


### PR DESCRIPTION
Falls der total_prize genau bei 0.3 bzw. 0.4 liegt, greift keine Bedingungen und die Anzeige ist unvollständig, d.h. keine Ampel und auch kein Preis werden angezeigt. 

Durch aufweichen der Bedingungen von ">" auf ">=", sind diese Grenzfälle nun enthalten und werden der gelben bzw. der roten Ampel zugeordnet.